### PR TITLE
tests: guard `libc::prctl` when using linux to work with macos

### DIFF
--- a/sp/tests/common/mod.rs
+++ b/sp/tests/common/mod.rs
@@ -73,9 +73,10 @@ impl Drop for WatchdogGuard {
 /// Dump every thread's backtrace by attaching gdb to our own pid. Best-effort:
 /// prints a note and continues if gdb is unavailable or cannot attach.
 fn dump_threads() {
-    // Let the gdb child ptrace us regardless of the yama ptrace_scope setting.
-    const PR_SET_PTRACER_ANY: libc::c_ulong = libc::c_ulong::MAX;
+    #[cfg(target_os = "linux")]
     unsafe {
+        // Let the gdb child ptrace us regardless of the yama ptrace_scope setting.
+        const PR_SET_PTRACER_ANY: libc::c_ulong = libc::c_ulong::MAX;
         libc::prctl(libc::PR_SET_PTRACER, PR_SET_PTRACER_ANY);
     }
     let pid = std::process::id().to_string();


### PR DESCRIPTION
This PR add an attr guard when using linux syscall, so gdb can attach it on the mid-run with `#[cfg(target_os = "linux")]` on `dump_threads` function. This was done to work with macos.